### PR TITLE
Fix: Issue error in fmlogit

### DIFF
--- a/R/fmlogit_main.R
+++ b/R/fmlogit_main.R
@@ -78,13 +78,17 @@ start.time=proc.time()
 
 # y has to be numerical. X can be numerical or factor/categorical
 Xclass = sapply(X,class)
-Xfac = which(Xclass %in% c("factor","character"))
-Xfacnames = colnames(X)[Xfac]
-strformFac = paste(Xfacnames,collapse="+")
-# This creates a formula ~dummies, which goes into model.matrix to generate dummies
-Xdum = model.matrix(as.formula(paste("~",strformFac,sep="")),data=X)
-X = cbind(X,Xdum); X = X[,-Xfac]
 
+# Get factor and character columns
+Xfac = which(Xclass %in% c("factor","character"))
+
+if( length(Xfac > 0)){
+  Xfacnames = colnames(X)[Xfac]
+  strformFac = paste(Xfacnames,collapse="+")
+  # This creates a formula ~dummies, which goes into model.matrix to generate dummies
+  Xdum = model.matrix(as.formula(paste("~",strformFac,sep="")),data=X)
+  X = cbind(X,Xdum); X = X[,-Xfac] 
+}
 
 Xnames = colnames(X); ynames = colnames(y)
 X = as.matrix(X); y = as.matrix(y)
@@ -98,7 +102,8 @@ n = dim(X)[1]
 remove(xy)
 
 # remove pre-existing constant variables
-X = X[,sapply(X,function(x) length(unique(x))!=1)]
+if( length(Xfac > 0 )) X = X[,sapply(X,function(x) length(unique(x))!=1)]
+
 # add constant term if necessary
 X = cbind(X,rep(1,n))
 # here k is No. of explanatories, without the constant term. 

--- a/R/fmlogit_main.R
+++ b/R/fmlogit_main.R
@@ -82,6 +82,7 @@ Xclass = sapply(X,class)
 # Get factor and character columns
 Xfac = which(Xclass %in% c("factor","character"))
 
+# Check for categorical variables and generate dummies
 if( length(Xfac > 0)){
   Xfacnames = colnames(X)[Xfac]
   strformFac = paste(Xfacnames,collapse="+")


### PR DESCRIPTION
The main function, `fmlogit_main.R`, did not check for categorical variables, which produces an error:
```
Error in parse(text = x, keep.source = FALSE) :
:2:0: unexpected end of input
1: ~
^
```
I added a check for categorical variables in `fmlogit_main.R` so the function will now evaluate even if categorical variables are not in the data. 